### PR TITLE
Added namespace for all object creation

### DIFF
--- a/lib/classy_json/conversion.rb
+++ b/lib/classy_json/conversion.rb
@@ -33,6 +33,7 @@ module ClassyJSON
     end
 
     def set_attrs(k, v)
+      k = k.split('/').last
       instance_variable_set("@#{k}", v)
       self.class.send(:attr_reader, k)
     end

--- a/lib/classy_json/utils.rb
+++ b/lib/classy_json/utils.rb
@@ -23,12 +23,12 @@ module ClassyJSON
 
     def find_or_create(class_name)
       #searches for known constants
-      if Kernel.const_defined?(class_name)
-        klass = Object.const_get(class_name)
+      if ClassyJSON.const_defined?(class_name)
+        klass = ClassyJSON.const_get(class_name)
       else
         #if constant does not exist we create it and build
         #dynamic attributes
-        klass = Object.const_set(class_name, Class.new)
+        klass = ClassyJSON.const_set(class_name, Class.new)
         build_klass(klass)
         klass
       end

--- a/spec/classy_json/classy_json_spec.rb
+++ b/spec/classy_json/classy_json_spec.rb
@@ -4,11 +4,11 @@ describe ClassyJSON do
   describe 'objects' do
     let(:objs) { ClassyJSON.convert(fixture("twitter.json").read) }
     it 'with json object' do
-      expect(objs.result).to be_a Result
-      expect(objs.query).to be_a Query
+      expect(objs.result).to be_a ClassyJSON::Result
+      expect(objs.query).to be_a ClassyJSON::Query
     end
     it 'works with nested json' do
-      expect(objs.query.params).to be_a Param
+      expect(objs.query.params).to be_a ClassyJSON::Param
     end
   end
   describe 'arrays' do
@@ -16,7 +16,7 @@ describe ClassyJSON do
       let(:objs) { ClassyJSON.convert(fixture("github-jobs.json").read, "jobs") }
       it 'with json array' do
         expect(objs.jobs).to be_a Array
-        expect(objs.jobs.first).to be_a Job
+        expect(objs.jobs.first).to be_a ClassyJSON::Job
       end
     end
     context 'invalid' do
@@ -33,7 +33,7 @@ describe ClassyJSON do
     end
     it 'works' do
       resp = ClassyJSON.convert(fixture("github-job.json").read, "job")
-      expect(resp.job).to be_a Job
+      expect(resp.job).to be_a ClassyJSON::Job
     end
   end
   describe 'nested objects' do


### PR DESCRIPTION
Prior to this all objects and constants were rolled up to the Object
level in ruby which could conflict with other implementations.  This now
namespaces all new objects within the ClassyJSON module
